### PR TITLE
Fix compilation issue

### DIFF
--- a/src/api-video-surface.c
+++ b/src/api-video-surface.c
@@ -19,9 +19,7 @@
 #include <vdpau/vdpau.h>
 #include "api.h"
 #include "trace.h"
-#include "libavutil/avassert.h"
 #include "libavutil/pixfmt.h"
-#include "libavutil/pixdesc.h"
 
 VdpStatus
 vdpVideoSurfaceCreate(VdpDevice device, VdpChromaType chroma_type, uint32_t width, uint32_t height,


### PR DESCRIPTION
I noticed the project wouldn't compile and it seems that the macros were misnamed(originally AV_PIX_FMT instead of PIX_FMT), and the library wasn't included.
