### PR TITLE
Don't output initialization message on stdout

### DIFF
--- a/src/entry.c
+++ b/src/entry.c
@@ -131,7 +131,6 @@ va_gl_library_constructor(void)
     // initialize tracer
     traceSetTarget(stdout);
     traceSetHook(trc_hk, NULL);
-    traceInfo("Software VDPAU backend library initialized\n");
 #ifdef NDEBUG
     traceEnableTracing(0);
 #else
@@ -154,6 +153,7 @@ va_gl_library_constructor(void)
         }
         free(value_lc);
     }
+    traceInfo("Software VDPAU backend library initialized\n");
 }
 
 __attribute__((destructor))


### PR DESCRIPTION
Unless tracing is enabled (through NDEBUG or to a file), the
initialization message should not go to stdout since it may break
program output. Move the initialization message at the end of the entry
function, once tracing has been setup correctly.

See:
 https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=780228