### PR TITLE
Unbreak building tests on BSD systems

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(test-000 EXCLUDE_FROM_ALL test-000.cc)
 foreach(_test ${_vdpau_tests})
     add_executable(${_test} EXCLUDE_FROM_ALL "${_test}.c" tests-common.c)
     add_dependencies(${_test} ${DRIVER_NAME})
-    target_link_libraries(${_test} dl)
+    target_link_libraries(${_test} ${CMAKE_DL_LIBS})
 endforeach(_test)
 
 foreach(_test ${_all_tests})


### PR DESCRIPTION
```
$ make check
[...]
[ 44%] Linking C executable test-006
cd tests && /usr/local/bin/cmake -E cmake_link_script CMakeFiles/test-006.dir/link.txt --verbose=1
/usr/bin/cc   -pthread -std=gnu99   CMakeFiles/test-006.dir/test-006.c.o CMakeFiles/test-006.dir/tests-common.c.o  -o test-006 -Wl,-rpath,/usr/local/lib /usr/local/lib/libX11.so -ldl
/usr/bin/ld: cannot find -ldl
cc: error: linker command failed with exit code 1 (use -v to see invocation)
```