### PR TITLE
3rdparty: Fix memory leak resulting from libva

### DIFF
--- a/src/api-device.cc
+++ b/src/api-device.cc
@@ -462,8 +462,7 @@ Resource::~Resource()
 {
     try {
         // cleaup libva
-        if (va_available)
-            vaTerminate(va_dpy);
+        vaTerminate(va_dpy);
 
         {
             GLXThreadLocalContext guard{root};


### PR DESCRIPTION
vaTerminate has to be called even if the
initialization of libva fails as it still
allocates resources that have to be cleaned
up in the terminate function.